### PR TITLE
Add new commandline option TARGET

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
     - workflow/*
+  pull_request:
+    branches:
+    - main
   schedule:
     - cron: '13 4 * * *' # Sync submodules daily
   workflow_dispatch:
@@ -42,6 +45,7 @@ jobs:
       run: >
         rake
         BUILD=reactos-nightly
+        TARGET=x86
         FAIL_FAST=true
         PACKER_LOG_PATH=build.log
         PKR_VAR_headless=true


### PR DESCRIPTION
Summary:
  * Add the new TARGET env var to rake.
    This let's you build both the standard `x86` (default)
    and the `x64` build.
    As a note of caution the `x64` build does not yet work!
  * Run the workflow on pull request.