### PR TITLE
Install gecko on RC and earlier

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -260,9 +260,9 @@ desc "Build OS images"
 task :build => [ISO_DIR, LOG_DIR, :download_gecko] do
   Rake::FileList['*.pkrvars.hcl'].each do |hcl|
     name = hcl.pathmap('%n').pathmap('%n')
+    next unless hcl =~ BUILD
     write_config(hcl)
     environment(name)
-    next unless hcl =~ BUILD
     Rake::Task[:download_iso].execute(name)
     file_glob = iso_glob(hcl, TARGET)
     iso_file  = iso_path(file_glob)

--- a/templates/unattend.inf.erb
+++ b/templates/unattend.inf.erb
@@ -82,7 +82,8 @@ ProductOption = <%=
 <%# rapps in the nightlies can auto install gecko but not yet in 0.4.14  %>
 %SystemRoot%\system32\cmd.exe /c "rapps /install gecko & shutdown /s /f /t 5"
 <% else %>
-%SystemRoot%\system32\cmd.exe /c "shutdown /s /f /t 5"
+<%# for older versions of ReactOS we simulate the rapps install %>
+%SystemRoot%\system32\cmd.exe /c "cd ""%USERPROFILE%\My Documents\"" & mkdir ""RAPPS Downloads"" & cd ""RAPPS Downloads"" & dwnl <%= WINE_GECKO_URL %> & msiexec.exe /i <%= File.basename(WINE_GECKO_URL) %> & shutdown /s /f /t 5"
 <% end %>
 ; Enable the next line (+ the GuiRunOnce section) to enable the lautus theme
 ; "rundll32.exe shell32.dll,Control_RunDLL desk.cpl desk,@Appearance /Action:ActivateMSTheme /file:%SYSTEMROOT%\Resources\themes\lautus\lautus.msstyles"


### PR DESCRIPTION
Summary:
  * Emulate the rapps install by downloading
    the gecko msi and then install it.