### PR TITLE
Enable download of official releases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -185,14 +185,15 @@ end
 
 desc "Download zipped ISO"
 task :download_iso, [:build] do |task, build|
-  case build
-  when %r{rc$}
-    url = ReactOS::URL.rc_url
-    download_file(url, ISO_DIR)
-  when %r{nightly$}
-    url = ReactOS::URL.nightly_url(TARGET)
-    download_file(url, ISO_DIR)
-  end
+  url = case build
+        when %r{release$}
+          url = ReactOS::URL.release_url
+        when %r{rc$}
+          url = ReactOS::URL.rc_url
+        when %r{nightly$}
+          url = ReactOS::URL.nightly_url(TARGET)
+        end
+  download_file(url, ISO_DIR)
   Rake::Task[:extract_iso].execute
 end
 

--- a/lib/react_os/url.rb
+++ b/lib/react_os/url.rb
@@ -17,7 +17,15 @@ module ReactOS
     # determine the latest RC release URL
     def self.rc_url
       fetch_url('rc').each do |line|
-        next unless line =~ %r{href=.*-RC-.*-iso\.zip}
+        next unless line =~ %r{href=.*-RC-.*-iso\.zip/download}
+        return line.gsub(%r{.*href=["'](.*?)["'].*}xs, '\1').strip
+      end
+    end
+
+    # determine the latest RC release URL
+    def self.release_url
+      fetch_url('release').each do |line|
+        next unless line =~ %r{href=.*-release-\d+-.*-iso\.zip/download}
         return line.gsub(%r{.*href=["'](.*?)["'].*}xs, '\1').strip
       end
     end


### PR DESCRIPTION
Summary:
  * Enable download of official releases.
  * Don't yet build them as they are still producing
    a kernel panic during build.