### PR TITLE
Change description for iso_file

### DIFF
--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -50,7 +50,7 @@ variable "iso_checksum" {
 }
 variable "iso_file" {
   type        = string
-  description = "Base name of ISO file used for installation."
+  description = "Path to the ISO file used for installation."
 }
 variable "ros_fstype" {
   type        = string


### PR DESCRIPTION
Summary:
  * Change wording for iso_file variable
    description to ensure the path is passed
    not just the basename.