### PR TITLE
Bugfix: Iso file path algorithm

### DIFF
--- a/lib/xorriso.rb
+++ b/lib/xorriso.rb
@@ -6,14 +6,17 @@ class Xorriso
 
   # find and return the iso file based on pattern
   def self.path(pattern)
-    p pattern
-    @iso_path = Find.find('.').find { |f| File.file?(f) && f =~ pattern }
+    found = Find.find('.').find.inject([]) do |found, path|
+      found.push(path) if File.file?(path) && path =~ pattern
+      found
+    end
+    @iso_path = found.sort.last
   end
 
   # modify the ISO file for unattended installation via file injection.
   def self.modify(iso_path)
     @iso_path = iso_path
-    @inject_files.each do |entry| 
+    @inject_files.each do |entry|
       inject_file(entry[:source], entry[:target])
     end
   end


### PR DESCRIPTION
Summary:
  * When more than one file was in the iso directory
    The first match was taken not the latest version.