### PR TITLE
The BtrFS option installs now reliably

### DIFF
--- a/packer/reactos-nightly.pkrvars.hcl
+++ b/packer/reactos-nightly.pkrvars.hcl
@@ -2,3 +2,4 @@
 name            = "reactos"
 version         = "nightly"
 target          = "workstation"
+ros_fstype      = "BtrFS"


### PR DESCRIPTION
BtrFS works now without issues during the installation and is made the default file system when installing the nightlies.