### PR TITLE
Add require file for newer versions of packer

### DIFF
--- a/packer/require.pkr.hcl
+++ b/packer/require.pkr.hcl
@@ -1,0 +1,12 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = "~> 1"
+      source  = "github.com/hashicorp/qemu"
+    }
+    virtualbox = {
+       version = "~> 1"
+       source  = "github.com/hashicorp/virtualbox"
+    }
+  }
+}


### PR DESCRIPTION
Packer uses a plugin model where first the
plugins need to be downloaded.